### PR TITLE
CMakeLists.txt replacing hard coded installation paths with more flex…

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,8 +52,8 @@ target_link_libraries(ksmoothdock ksmoothdock_lib ${LIBS})
 
 # Install
 
-install(TARGETS ksmoothdock RUNTIME DESTINATION bin)
-install(FILES ksd.ksmoothdock.desktop DESTINATION /usr/share/applications)
+install(TARGETS ksmoothdock RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(FILES ksd.ksmoothdock.desktop DESTINATION ${CMAKE_INSTALL_PREFIX}/share/applications)
 
 # Uninstall
 


### PR DESCRIPTION
Patch needed for the nix package to build because nix apps are self contained and can't install in default paths.