### PR TITLE
Use task icon if we can't find an application.

### DIFF
--- a/src/view/dock_panel.cc
+++ b/src/view/dock_panel.cc
@@ -737,9 +737,16 @@ void DockPanel::addTask(const TaskInfo& task) {
         this, model_, app->name, orientation_, app->icon, minSize_,
         maxSize_, app->command, app->taskCommand, /*pinned=*/false));
   } else {
-    items_.insert(items_.begin() + i, std::make_unique<Program>(
-        this, model_, task.program, orientation_, "xapp", minSize_,
-        maxSize_, task.command, task.command, /*pinned=*/false));
+      if (task.icon.isNull()) {
+          items_.insert(items_.begin() + i, std::make_unique<Program>(
+                        this, model_, task.program, orientation_, "xapp", minSize_,
+                        maxSize_, task.command, task.command, /*pinned=*/false));
+      }
+      else {
+          items_.insert(items_.begin() + i, std::make_unique<Program>(
+                        this, model_, task.program, orientation_, task.icon, minSize_,
+                        maxSize_, task.command, task.command, /*pinned=*/false));
+      }
   }
   items_[i]->addTask(task);
 }

--- a/src/view/program.cc
+++ b/src/view/program.cc
@@ -54,6 +54,26 @@ Program::Program(DockPanel* parent, MultiDockModel* model, const QString& label,
   });
 }
 
+Program::Program(DockPanel* parent, MultiDockModel* model, const QString& label,
+                 Qt::Orientation orientation, const QPixmap& icon, int minSize,
+                 int maxSize, const QString& command, const QString& taskCommand, bool pinned)
+    : IconBasedDockItem(parent, label, orientation, icon, minSize, maxSize),
+      model_(model),
+      command_(command),
+      taskCommand_(taskCommand),
+      pinned_(pinned),
+      demandsAttention_(false),
+      attentionStrong_(false) {
+    createMenu();
+
+    animationTimer_.setInterval(500);
+    connect(&animationTimer_, &QTimer::timeout, this, [this]() {
+        attentionStrong_ = !attentionStrong_;
+        parent_->update();
+    });
+}
+
+
 void Program::draw(QPainter *painter) const {
   if ((!tasks_.empty() && active()) || attentionStrong_) {
     drawHighlightedIcon(model_->backgroundColor(), left_, top_, getWidth(), getHeight(),

--- a/src/view/program.h
+++ b/src/view/program.h
@@ -52,6 +52,10 @@ class Program : public QObject, public IconBasedDockItem {
       Qt::Orientation orientation, const QString& iconName, int minSize,
       int maxSize, const QString& command, const QString& taskCommand, bool pinned);
 
+  Program(DockPanel* parent, MultiDockModel* model, const QString& label,
+          Qt::Orientation orientation, const QPixmap& icon, int minSize,
+          int maxSize, const QString& command, const QString& taskCommand, bool pinned);
+
   ~Program() override = default;
 
   void draw(QPainter* painter) const override;


### PR DESCRIPTION
Instead of the previous fallback to the X logo, we should first check to see if we already have a task icon. If we do, we can just fall back to that.